### PR TITLE
Fundreg and ROR support

### DIFF
--- a/examples/config/fundreg.json
+++ b/examples/config/fundreg.json
@@ -1,0 +1,34 @@
+{
+        "field-name": "grantNumberAgency",
+        "term-uri-field": "grantNumberAgency",
+        "js-url": "/cvoc/js/funders.js",
+        "protocol": "orcid2",
+        "retrieval-uri": "https://data.crossref.org/fundingdata/funder/{0}",
+        "allow-free-text": true,
+        "prefix": "http://dx.doi.org/10.13039/",
+        "managed-fields": {},
+        "languages":"",
+        "vocabs": {
+            "funders": {
+                "uriSpace": "http://dx.doi.org/10.13039/"
+            }
+        },
+        "retrieval-filtering": {
+            "@context": {
+                "termName": "https://schema.org/name",
+                "scheme": "http://www.w3.org/2004/02/skos/core#inScheme",
+                "lang": "@language",
+                "content": "@value"
+            },
+            "scheme": {
+                "pattern": "http://data.crossref.org/fundingdata/vocabulary"
+            },
+            "termName": {
+                "pattern": "{0}",
+                "params": ["/altLabel/Label=*/literalForm"]
+            },
+            "@type": {
+                "pattern": "https://schema.org/Organization"
+            }
+        }
+    }

--- a/examples/config/fundreg.json
+++ b/examples/config/fundreg.json
@@ -1,4 +1,5 @@
-{
+[
+    {
         "field-name": "grantNumberAgency",
         "term-uri-field": "grantNumberAgency",
         "js-url": "/cvoc/js/funders.js",
@@ -32,3 +33,4 @@
             }
         }
     }
+]

--- a/examples/config/grantNumberAgencyFundreg.json
+++ b/examples/config/grantNumberAgencyFundreg.json
@@ -2,7 +2,7 @@
     {
         "field-name": "grantNumberAgency",
         "term-uri-field": "grantNumberAgency",
-        "js-url": "/cvoc/js/funders.js",
+        "js-url": "/cvoc/js/fundreg.js",
         "protocol": "fundreg",
         "retrieval-uri": "https://data.crossref.org/fundingdata/funder/{0}",
         "allow-free-text": true,

--- a/examples/config/grantNumberAgencyFundreg.json
+++ b/examples/config/grantNumberAgencyFundreg.json
@@ -3,7 +3,7 @@
         "field-name": "grantNumberAgency",
         "term-uri-field": "grantNumberAgency",
         "js-url": "/cvoc/js/funders.js",
-        "protocol": "orcid2",
+        "protocol": "fundreg",
         "retrieval-uri": "https://data.crossref.org/fundingdata/funder/{0}",
         "allow-free-text": true,
         "prefix": "http://dx.doi.org/10.13039/",

--- a/examples/config/rorAuthAffiliation.json
+++ b/examples/config/rorAuthAffiliation.json
@@ -1,0 +1,36 @@
+[
+    {
+        "field-name": "authorAffiliation",
+        "term-uri-field": "authorAffiliation",
+        "js-url": "/cvoc/js/ror.js",
+        "protocol": "ror",
+        "retrieval-uri": "https://api.ror.org/organizations/{0}",
+        "allow-free-text": true,
+        "prefix": "https://ror.org/",
+        "managed-fields": {},
+        "languages":"",
+        "vocabs": {
+            "funders": {
+                "uriSpace": "https://ror.org/"
+            }
+        },
+        "retrieval-filtering": {
+            "@context": {
+                "termName": "https://schema.org/name",
+                "scheme": "http://www.w3.org/2004/02/skos/core#inScheme",
+                "lang": "@language",
+                "content": "@value"
+            },
+            "scheme": {
+                "pattern": "http://www.grid.ac/ontology/"
+            },
+            "termName": {
+                "pattern": "{0}",
+                "params": ["/name"]
+            },
+            "@type": {
+                "pattern": "https://schema.org/Organization"
+            }
+        }
+    }
+]

--- a/examples/config/rorAuthAffiliation.json
+++ b/examples/config/rorAuthAffiliation.json
@@ -10,7 +10,7 @@
         "managed-fields": {},
         "languages":"",
         "vocabs": {
-            "funders": {
+            "rors": {
                 "uriSpace": "https://ror.org/"
             }
         },

--- a/scripts/cvocutils.js
+++ b/scripts/cvocutils.js
@@ -1,0 +1,61 @@
+//Common Methods - used in more than one script
+
+// Put the text in a result that matches the term in a span with class
+// select2-rendered__match that can be styled (e.g. bold)
+function markMatch2(text, term) {
+    // Find where the match is
+    var match = text.toUpperCase().indexOf(term.toUpperCase());
+    var $result = $('<span></span>');
+    // If there is no match, move on
+    if (match < 0) {
+        return $result.text(text);
+    }
+
+    // Put in whatever text is before the match
+    $result.text(text.substring(0, match));
+
+    // Mark the match
+    var $match = $('<span class="select2-rendered__match"></span>');
+    $match.text(text.substring(match, match + term.length));
+
+    // Append the matching text
+    $result.append($match);
+
+    // Put in whatever is after the match
+    $result.append(text.substring(match + term.length));
+
+    return $result;
+}
+
+function storeValue(prefix, id, value) {
+    try {
+        if(localStorage.getItem(prefix + id)==null) {
+            // Store the most recent 1000 values across all scripts
+            //ToDo: Use IndexedDB to manage storage for each script separately and avoid impacting other tools using localStorage
+            if (localStorage.length > 1000) {
+                localStorage.removeItem(localStorage.key(0));
+            }
+            localStorage.setItem(prefix + id, name + "#" + funder.message['alt-names']);
+        }
+    } catch (e) {
+        console.log("Problem using localStorage: " + e);
+    }
+}
+
+function getValue(prefix, id) {
+    try {
+        let altNames='';
+        let name = localStorage.getItem(prefix + id);
+        if(name !== null) {
+            name=name.substring(prefix.length);
+            let pos = name.indexOf('#');
+            if(pos > 0) {
+                altNames=name.substring(pos+1);
+                name=name.substring(0, pos);
+            }
+        }
+        return {name, altNames};
+    } catch (e) {
+        console.log("Problem getting value from localStorage: " + e);
+    }
+}

--- a/scripts/cvocutils.js
+++ b/scripts/cvocutils.js
@@ -35,7 +35,7 @@ function storeValue(prefix, id, value) {
             if (localStorage.length > 1000) {
                 localStorage.removeItem(localStorage.key(0));
             }
-            localStorage.setItem(prefix + id, name + "#" + funder.message['alt-names']);
+            localStorage.setItem(prefix + id, value);
         }
     } catch (e) {
         console.log("Problem using localStorage: " + e);
@@ -47,10 +47,9 @@ function getValue(prefix, id) {
         let altNames='';
         let name = localStorage.getItem(prefix + id);
         if(name !== null) {
-            name=name.substring(prefix.length);
             let pos = name.indexOf('#');
             if(pos > 0) {
-                altNames=name.substring(pos+1);
+                altNames=name.substring(pos+1).split(',');
                 name=name.substring(0, pos);
             }
         }

--- a/scripts/fundreg.js
+++ b/scripts/fundreg.js
@@ -1,0 +1,242 @@
+console.log("funders.js..");
+const fundregSelector = "span[data-cvoc-protocol='fundreg']";
+const fundregInputSelector = "input[data-cvoc-protocol='fundreg']";
+const fundregRetrievalUrl = "https://api.crossref.org/funders";
+const fundregPrefix = "fundreg";
+//Max chars that displays well for a child field
+const fundregMaxLength = 26;
+
+$(document).ready(function() {
+    var head = document.getElementsByTagName('head')[0];
+    var js = document.createElement("script");
+    js.type = "text/javascript";
+    js.src = "./cvocutils.js";
+    head.appendChild(js);
+    
+    expandFunders();
+    updateFunderInputs();
+});
+
+function expandFunders() {
+    console.log("expandFunders");
+    // Check each selected element
+    $(fundregSelector).each(function() {
+        var funderElement = this;
+        // If it hasn't already been processed
+        if (!$(funderElement).hasClass('expanded')) {
+            // Mark it as processed
+            $(funderElement).addClass('expanded');
+            var id = funderElement.textContent;
+            if (!id.startsWith("http://dx.doi.org/10.13039/")) {
+                funderElement.innerHTML = getFunderDisplayHtml(id, ['No Crossref Entry']);
+            } else {
+                //Remove the URL prefix - "http://dx.doi.org/10.13039/".length = 27
+                id = id.substring(27);
+                //Check for cached entry
+                let value = getValue(fundregPrefix, id);
+                if(value.name !=null) {
+                    funderElement.innerHTML = getFunderDisplayHtml(value.name, value.altNames);
+                } else {
+                
+
+                    // Try it as an CrossRef Funders entry (could validate that it has the right form or can just let the GET fail)
+                    $.ajax({
+                        type: "GET",
+                        url: retrievalUrl + "/" + id,
+                        dataType: 'json',
+                        //Adding this, and using https is supposed to let us call a faster pool of machines
+                        //(They will contact us if they see problems - see https://api.crossref.org/swagger-ui/index.html.)
+                        data: 'mailto=dataverse-gdcc@googlegroups.com',
+                        headers: {
+                            'Accept': 'application/json',
+                        },
+                        success: function(funder, status) {
+                            console.log(funder);
+                            // If found, construct the HTML for display
+                            var name = funder.message.name;
+                            var altNames= funder.message['alt-names'];
+    
+                            funderElement.innerHTML = getFunderDisplayHtml(name, altNames);
+                            //Store values in localStorage to avoid repeating calls to CrossRef
+                            setValue(fundregPrefix, id, name + "#" + altNames);
+                        },
+                        failure: function(jqXHR, textStatus, errorThrown) {
+                            // Generic logging - don't need to do anything if 404 (leave
+                            // display as is)
+                            if (jqXHR.status != 404) {
+                                console.error("The following error occurred: " + textStatus, errorThrown);
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    });
+}
+
+function getFunderDisplayHtml(name, altNames) {
+    if (name.length >= fundregMaxLength) {
+        // show the first characters of a long name
+        // return item.text.substring(0,25) + "…";
+        altNames.unshift(name);
+        name=name.substring(0,fundregMaxLength) + "…";
+    }
+    return "<span title='" + altNames + "'>" + name + "</span>";
+}
+
+function updateFunderInputs() {
+    // For each input element within funderInputSelector elements
+    $(fundregInputSelector).each(function() {
+        var funderInput = this;
+        if (!funderInput.hasAttribute('data-funder')) {
+            // Random identifier
+            let num = Math.floor(Math.random() * 100000000000);
+            // Hide the actual input and give it a data-funder number so we can
+            // find it
+            $(funderInput).hide();
+            $(funderInput).attr('data-funder', num);
+            // Todo: if not displayed, wait until it is to then create the
+            // select 2 with a non-zero width
+            // Add a select2 element to allow search and provide a list of
+            // choices
+            var selectId = "funderAddSelect_" + num;
+            $(funderInput).after(
+                '<select id=' + selectId + ' class="form-control add-resource select2" tabindex="-1" aria-hidden="true">');
+            $("#" + selectId).select2({
+                theme: "classic",
+                tags: $(funderInput).attr('data-cvoc-allowfreetext'),
+                delay: 500,
+                templateResult: function(item) {
+                    // No need to template the searching text
+                    if (item.loading) {
+                        return item.text;
+                    }
+                    // markMatch bolds the search term if/where it appears in
+                    // the result
+                    var $result = markMatch2(item.text, term);
+                    return $result;
+                },
+                templateSelection: function(item) {
+                    // For a selection, format as in display mode
+                    //Find/remove the id number
+                    var pos = item.text.search(/, \d{9}/);
+                        console.log("pos: " + pos);
+                    if (pos >= 0) {
+                        console.log("pos greater than zero: " + pos);
+                        var name = item.text.substr(0, pos);
+                        var idnum = item.text.substr(pos+2);
+                        return getFunderDisplayHtml(name, altNames);
+                    }
+                    return getFunderDisplayHtml(name, ['No Crossref Entry']);
+                },
+                language: {
+                    searching: function(params) {
+                        // Change this to be appropriate for your application
+                        return 'Search by name or acronym…';
+                    }
+                },
+                placeholder: funderInput.hasAttribute("data-cvoc-placeholder") ? $(funderInput).attr('data-cvoc-placeholder') : "Select a funding agency",
+                minimumInputLength: 3,
+                allowClear: true,
+                ajax: {
+                    // Use an ajax call to CrossRef to retrieve matching results
+                    url: fundregRetrievalUrl,
+                    data: function(params) {
+                        term = params.term;
+                        if (!term) {
+                            term = "";
+                            console.log("no term!");
+                        }
+                        var query = {
+                            query: term,
+                            rows: 1000
+                            //See above - this put the request on a faster pool of machines
+                            mailto: 'dataverse-gdcc@googlegroups.com',
+                        }
+                        return query;
+                    },
+                    // request json
+                    headers: {
+                        'Accept': 'application/json'
+                    },
+                    processResults: function(data, page) {
+                        //console.log("Data dump BEGIN");
+                        //console.log(data);
+                        //console.log("Data dump END");
+                        return {
+                            results: data['message']['items']
+                                // Sort the list
+                                // Prioritize those with this as a token
+                                .sort((a, b) => (b.tokens.includes(data.message.query['search-terms'].toLowerCase())) ? 1 : -1)
+                                // Prioritize those with this alt-name
+                                .sort((a, b) => (b['alt-names'].includes(data.message.query['search-terms'])) ? 1 : -1)
+                                // Prioritize previously used entries
+                                .sort((a, b) => (getValue(fundregPrefix, b['id'])) ? 1 : -1)
+                                .map(
+                                    function(x) {
+                                        return {
+                                            text: x.name +", " + x.id,
+                                            id: x['uri'],
+                                            altNames: x['alt-names']
+                                        }
+                                    })
+                        };
+                    }
+                }
+            });
+            // If the input has a value already, format it the same way as if it
+            // were a new selection
+            var id = $(funderInput).val();
+            if (id.startsWith("http://dx.doi.org/10.13039/")) {
+                id = id.substring(27);
+                $.ajax({
+                    type: "GET",
+                    url: fundregRetrievalUrl + "/" + id,
+                    //See above - puts the request on a faster pool of machines
+                    data: 'mailto=dataverse-gdcc@googlegroups.com',
+                    dataType: 'json',
+                    headers: {
+                        'Accept': 'application/json'
+                    },
+                    success: function(funder, status) {
+                        var name = funder.message.name;
+                        console.log("name: " + name);
+                        //Display the name and id number in the selection menu
+                        var text = name + ", " + id;
+                        var newOption = new Option(text, id, true, true);
+                        newOption.altNames = funder.message['alt-names'];
+                        $('#' + selectId).append(newOption).trigger('change');
+                    },
+                    failure: function(jqXHR, textStatus, errorThrown) {
+                        if (jqXHR.status != 404) {
+                            console.error("The following error occurred: " + textStatus, errorThrown);
+                        }
+                    }
+                });
+            } else {
+                // If the initial value is not in CrossRef, just display it as is
+                var newOption = new Option(id, id, true, true);
+                $('#' + selectId).append(newOption).trigger('change');
+            }
+            // Could start with the selection menu open
+            // $("#" + selectId).select2('open');
+            // When a selection is made, set the value of the hidden input field
+            $('#' + selectId).on('select2:select', function(e) {
+                var data = e.params.data;
+                // For entries from CrossRef, the id and text are different
+                //For plain text entries (legacy or if tags are allowed), they are the same
+                if (data.id != data.text) {
+                    // we want just the funder url
+                    $("input[data-funder='" + num + "']").val(data.id);
+                } else {
+                    // Tags are allowed, so just enter the text as is
+                    $("input[data-funder='" + num + "']").val(data.id);
+                }
+            });
+            // When a selection is cleared, clear the hidden input
+            $('#' + selectId).on('select2:clear', function(e) {
+                $("input[data-funder='" + num + "']").attr('value', '');
+            });
+        }
+    });
+}

--- a/scripts/fundreg.js
+++ b/scripts/fundreg.js
@@ -4,13 +4,14 @@ var fundregInputSelector = "input[data-cvoc-protocol='fundreg']";
 var fundregRetrievalUrl = "https://api.crossref.org/funders";
 var fundregPrefix = "fundreg";
 //Max chars that displays well for a child field
-var fundregMaxLength = 26;
+var fundregMaxLength = 31;
 
 $(document).ready(function() {
     var head = document.getElementsByTagName('head')[0];
     var js = document.createElement("script");
     js.type = "text/javascript";
-    js.src = "./cvocutils.js";
+    js.src = "/cvoc/js/cvocutils.js";
+    js.async=false;
     head.appendChild(js);
     js.addEventListener('load', () => {
         expandFunders();
@@ -29,16 +30,15 @@ function expandFunders() {
             $(funderElement).addClass('expanded');
             var id = funderElement.textContent;
             if (!id.startsWith("http://dx.doi.org/10.13039/")) {
-                 $(funderElement).html(getFunderDisplayHtml(id, ['No Crossref Entry']));
+                $(funderElement).html(getFunderDisplayHtml(id, ['No Crossref Entry'], false));
             } else {
                 //Remove the URL prefix - "http://dx.doi.org/10.13039/".length = 27
                 id = id.substring(27);
                 //Check for cached entry
                 let value = getValue(fundregPrefix, id);
                 if(value.name !=null) {
-                    $(funderElement).html(getFunderDisplayHtml(value.name, value.altNames));
+                    $(funderElement).html(getFunderDisplayHtml(value.name, value.altNames, false));
                 } else {
-                
 
                     // Try it as an CrossRef Funders entry (could validate that it has the right form or can just let the GET fail)
                     $.ajax({
@@ -56,8 +56,8 @@ function expandFunders() {
                             // If found, construct the HTML for display
                             var name = funder.message.name;
                             var altNames= funder.message['alt-names'];
-    
-                            funderElement.innerHTML = getFunderDisplayHtml(name, altNames);
+
+                            $(funderElement).html(getFunderDisplayHtml(name, altNames, false));
                             //Store values in localStorage to avoid repeating calls to CrossRef
                             storeValue(fundregPrefix, id, name + "#" + altNames);
                         },
@@ -75,13 +75,12 @@ function expandFunders() {
     });
 }
 
-function getFunderDisplayHtml(name, altNames) {
-    if(typeof(altNames) == 'undefined') {
-        altNames=[];
+function getFunderDisplayHtml(name, altNames, truncate=true) {
+    if (typeof(altNames) == 'undefined') {
+        altNames = [];
     }
-    if (name.length >= fundregMaxLength) {
+    if (truncate && (name.length >= fundregMaxLength)) {
         // show the first characters of a long name
-        // return item.text.substring(0,25) + "…";
         altNames.unshift(name);
         name=name.substring(0,fundregMaxLength) + "…";
     }

--- a/scripts/ror.js
+++ b/scripts/ror.js
@@ -1,0 +1,234 @@
+console.log("ror.js..");
+const rorSelector = "span[data-cvoc-protocol='ror']";
+const rorInputSelector = "input[data-cvoc-protocol='ror']";
+const rorRetrievalUrl = "https://api.ror.org/organizations";
+const rorIdStem = "https://ror.org/";
+const rorPrefix = "ror";
+//Max chars that displays well for a child field
+const rorMaxLength = 26;
+
+$(document).ready(function() {
+    var head = document.getElementsByTagName('head')[0];
+    var js = document.createElement("script");
+    js.type = "text/javascript";
+    js.src = "./cvocutils.js";
+    head.appendChild(js);
+    
+    expandRors();
+    updateRorInputs();
+});
+
+function expandRors() {
+    console.log("expandRors");
+    // Check each selected element
+    $(rorSelector).each(function() {
+        var rorElement = this;
+        // If it hasn't already been processed
+        if (!$(rorElement).hasClass('expanded')) {
+            // Mark it as processed
+            $(rorElement).addClass('expanded');
+            var id = rorElement.textContent;
+            if (!id.startsWith(rorIdStem)) {
+                getRorDisplayHtml(name, ['No ROR Entry']);
+            } else {
+                //Remove the URL prefix - "https://ror.org/".length = 16
+                id = id.substring(rorIdStem.length);
+                //Check for cached entry
+                let value = getValue(rorPrefix, id);
+                if(value.name !=null) {
+                    rorElement.innerHTML = getRorDisplayHtml(value.name, value.altNames);
+                } else {
+                    // Try it as an ROR entry (could validate that it has the right form or can just let the GET fail)
+                    $.ajax({
+                        type: "GET",
+                        url: retrievalUrl + "/" + id,
+                        dataType: 'json',
+                        headers: {
+                            'Accept': 'application/json',
+                        },
+                        success: function(ror, status) {
+                            console.log(ror);
+                            // If found, construct the HTML for display
+                            var name = ror.name;
+                            var altNames= ror.acronyms;
+    
+                            rorElement.innerHTML = getRorDisplayHtml(name, altNames);
+                            //Store values in localStorage to avoid repeating calls to CrossRef
+                            setValue(rorPrefix, id, name + "#" + altNames);
+                        },
+                        failure: function(jqXHR, textStatus, errorThrown) {
+                            // Generic logging - don't need to do anything if 404 (leave
+                            // display as is)
+                            if (jqXHR.status != 404) {
+                                console.error("The following error occurred: " + textStatus, errorThrown);
+                            }
+                        }
+                    });
+                }
+            }
+        }
+    });
+}
+
+function getRorDisplayHtml(name, altNames) {
+    if (name.length >= fundregMaxLength) {
+        // show the first characters of a long name
+        // return item.text.substring(0,25) + "…";
+        altNames.unshift(name);
+        name=name.substring(0,fundregMaxLength) + "…";
+    }
+    return "<span title='" + altNames + "'>" + name + "</span>";
+}
+
+function updateRorInputs() {
+    // For each input element within rorInputSelector elements
+    $(rorInputSelector).each(function() {
+        var rorInput = this;
+        if (!rorInput.hasAttribute('data-ror')) {
+            // Random identifier
+            let num = Math.floor(Math.random() * 100000000000);
+            // Hide the actual input and give it a data-ror number so we can
+            // find it
+            $(rorInput).hide();
+            $(rorInput).attr('data-ror', num);
+            // Todo: if not displayed, wait until it is to then create the
+            // select 2 with a non-zero width
+            // Add a select2 element to allow search and provide a list of
+            // choices
+            var selectId = "rorAddSelect_" + num;
+            $(rorInput).after(
+                '<select id=' + selectId + ' class="form-control add-resource select2" tabindex="-1" aria-hidden="true">');
+            $("#" + selectId).select2({
+                theme: "classic",
+                tags: $(rorInput).attr('data-cvoc-allowfreetext'),
+                delay: 500,
+                templateResult: function(item) {
+                    // No need to template the searching text
+                    if (item.loading) {
+                        return item.text;
+                    }
+                    // markMatch bolds the search term if/where it appears in
+                    // the result
+                    var $result = markMatch2(item.text, term);
+                    return $result;
+                },
+                templateSelection: function(item) {
+                    // For a selection, format as in display mode
+                    //Find/remove the id number
+                    var pos = item.text.search(/, \d{9}/);
+                        console.log("pos: " + pos);
+                    if (pos >= 0) {
+                        console.log("pos greater than zero: " + pos);
+                        var name = item.text.substr(0, pos);
+                        var idnum = item.text.substr(pos+2);
+                        return getRorDisplayHtml(name, altNames);
+                    }
+                    return getRorDisplayHtml(name, ['No ROR Entry']);
+                },
+                language: {
+                    searching: function(params) {
+                        // Change this to be appropriate for your application
+                        return 'Search by name or acronym…';
+                    }
+                },
+                placeholder: rorInput.hasAttribute("data-cvoc-placeholder") ? $(rorInput).attr('data-cvoc-placeholder') : "Select a research organization",
+                minimumInputLength: 3,
+                allowClear: true,
+                ajax: {
+                    // Use an ajax call to ROR to retrieve matching results
+                    url: rorRetrievalUrl,
+                    data: function(params) {
+                        term = params.term;
+                        if (!term) {
+                            term = "";
+                            console.log("no term!");
+                        }
+                        var query = {
+                            query: term,
+                        }
+                        return query;
+                    },
+                    // request json
+                    headers: {
+                        'Accept': 'application/json'
+                    },
+                    processResults: function(data, params) {
+                        //console.log("Data dump BEGIN");
+                        //console.log(data);
+                        //console.log("Data dump END");
+                        return {
+                            results: data['items']
+                                // Sort the list
+                                // Prioritize active orgs
+                                .sort((a, b) => (b.status === 'active') ? 1 : -1)
+                                // Prioritize those with this acronym
+                                .sort((a, b) => (b.acronyms.includes(params.query)) ? 1 : -1)
+                                // Prioritize previously used entries
+                                .sort((a, b) => (getValue(rorPrefix, b['id'])) ? 1 : -1)
+                                .map(
+                                    function(x) {
+                                        return {
+                                            text: x.name +", " + x.id,
+                                            id: x.id,
+                                            altNames: x.acronyms,
+                                            urls: x.links
+                                        }
+                                    })
+                        };
+                    }
+                }
+            });
+            // If the input has a value already, format it the same way as if it
+            // were a new selection
+            var id = $(rorInput).val();
+            if (id.startsWith(rorIdStem)) {
+                id = id.substring(rorIdStem.length);
+                $.ajax({
+                    type: "GET",
+                    url: rorRetrievalUrl + "/" + id,
+                    dataType: 'json',
+                    headers: {
+                        'Accept': 'application/json'
+                    },
+                    success: function(ror, status) {
+                        var name = ror.name;
+                        //Display the name and id number in the selection menu
+                        var text = name + ", " + ror.id;
+                        var newOption = new Option(text, id, true, true);
+                        newOption.altNames = ror.acronyms;
+                        $('#' + selectId).append(newOption).trigger('change');
+                    },
+                    failure: function(jqXHR, textStatus, errorThrown) {
+                        if (jqXHR.status != 404) {
+                            console.error("The following error occurred: " + textStatus, errorThrown);
+                        }
+                    }
+                });
+            } else {
+                // If the initial value is not in CrossRef, just display it as is
+                var newOption = new Option(id, id, true, true);
+                newOption.altNames = ['No ROR Entry'];
+                $('#' + selectId).append(newOption).trigger('change');
+            }
+            // Could start with the selection menu open
+            // $("#" + selectId).select2('open');
+            // When a selection is made, set the value of the hidden input field
+            $('#' + selectId).on('select2:select', function(e) {
+                var data = e.params.data;
+                // For entries from ROR, the id and text are different
+                //For plain text entries (legacy or if tags are allowed), they are the same
+                if (data.id != data.text) {
+                    // we want just the ror url
+                    $("input[data-ror='" + num + "']").val(data.id);
+                } else {
+                    // Tags are allowed, so just enter the text as is
+                    $("input[data-ror='" + num + "']").val(data.id);
+                }
+            });
+            // When a selection is cleared, clear the hidden input
+            $('#' + selectId).on('select2:clear', function(e) {
+                $("input[data-ror='" + num + "']").attr('value', '');
+            });
+        }
+    });
+}

--- a/scripts/ror.js
+++ b/scripts/ror.js
@@ -1,11 +1,11 @@
 console.log("ror.js..");
-const rorSelector = "span[data-cvoc-protocol='ror']";
-const rorInputSelector = "input[data-cvoc-protocol='ror']";
-const rorRetrievalUrl = "https://api.ror.org/organizations";
-const rorIdStem = "https://ror.org/";
-const rorPrefix = "ror";
+var rorSelector = "span[data-cvoc-protocol='ror']";
+var rorInputSelector = "input[data-cvoc-protocol='ror']";
+var rorRetrievalUrl = "https://api.ror.org/organizations";
+var rorIdStem = "https://ror.org/";
+var rorPrefix = "ror";
 //Max chars that displays well for a child field
-const rorMaxLength = 26;
+var rorMaxLength = 26;
 
 $(document).ready(function() {
     var head = document.getElementsByTagName('head')[0];
@@ -13,9 +13,10 @@ $(document).ready(function() {
     js.type = "text/javascript";
     js.src = "./cvocutils.js";
     head.appendChild(js);
-    
-    expandRors();
-    updateRorInputs();
+    js.addEventListener('load', () => {
+        expandRors();
+        updateRorInputs();
+    })
 });
 
 function expandRors() {
@@ -41,7 +42,7 @@ function expandRors() {
                     // Try it as an ROR entry (could validate that it has the right form or can just let the GET fail)
                     $.ajax({
                         type: "GET",
-                        url: retrievalUrl + "/" + id,
+                        url: rorRetrievalUrl + "/" + id,
                         dataType: 'json',
                         headers: {
                             'Accept': 'application/json',
@@ -54,7 +55,7 @@ function expandRors() {
     
                             rorElement.innerHTML = getRorDisplayHtml(name, altNames);
                             //Store values in localStorage to avoid repeating calls to CrossRef
-                            setValue(rorPrefix, id, name + "#" + altNames);
+                            storeValue(rorPrefix, id, name + "#" + altNames);
                         },
                         failure: function(jqXHR, textStatus, errorThrown) {
                             // Generic logging - don't need to do anything if 404 (leave
@@ -71,13 +72,16 @@ function expandRors() {
 }
 
 function getRorDisplayHtml(name, altNames) {
-    if (name.length >= fundregMaxLength) {
+    if(typeof(altNames) == 'undefined') {
+        altNames=[];
+    }
+    if (name.length >= rorMaxLength) {
         // show the first characters of a long name
         // return item.text.substring(0,25) + "…";
         altNames.unshift(name);
-        name=name.substring(0,fundregMaxLength) + "…";
+        name=name.substring(0,rorMaxLength) + "…";
     }
-    return "<span title='" + altNames + "'>" + name + "</span>";
+    return $('<span></span>').append(name).attr("title", altNames);
 }
 
 function updateRorInputs() {
@@ -115,11 +119,10 @@ function updateRorInputs() {
                 templateSelection: function(item) {
                     // For a selection, format as in display mode
                     //Find/remove the id number
+                    var name=item.text;
                     var pos = item.text.search(/, \d{9}/);
-                        console.log("pos: " + pos);
                     if (pos >= 0) {
-                        console.log("pos greater than zero: " + pos);
-                        var name = item.text.substr(0, pos);
+                        name = name.substr(0, pos);
                         var idnum = item.text.substr(pos+2);
                         return getRorDisplayHtml(name, altNames);
                     }


### PR DESCRIPTION
Requires https://github.com/IQSS/dataverse/pull/9402 / Dataverse 5.14+ which adds support for using external vocab support on a single child field.

Adds initial support for fields interacting with CrossRef's Funder Registry and the Research Organization Registry. The example json registration fragments apply these to the grantNumberAgency and authorAffiliation fields in the citation block, respectively.