### PR TITLE
quick keyword example

### DIFF
--- a/examples/config/keywordExample.json
+++ b/examples/config/keywordExample.json
@@ -1,0 +1,47 @@
+[{
+    "field-name": "keyword",
+    "term-uri-field": "keywordValue",
+    "cvoc-url": "https://demo.skosmos.org/",
+    "js-url": "https://gdcc.github.io/dataverse-external-vocab-support/scripts/skosmos.js",
+    "protocol": "skosmos",
+    "retrieval-uri": "https://demo.skosmos.org/rest/v1/data?uri={0}",
+    "term-parent-uri": "",
+    "allow-free-text": false,
+    "languages":"en, fr, es, ru",
+    "vocabs": {
+        "unesco": {
+            "vocabularyUri": "http://skos.um.es/unescothes/CS000",
+            "uriSpace": "http://skos.um.es/unescothes/"
+        }
+    },
+    "managed-fields": {
+        "vocabularyName": "keywordVocabulary",
+        "vocabularyUri": "keywordVocabularyURI"
+    },
+    "retrieval-filtering": {
+        "@context": {
+            "termName": "https://schema.org/name",
+            "vocabularyName": "https://dataverse.org/schema/vocabularyName",
+            "vocabularyUri": "https://dataverse.org/schema/vocabularyUri",
+            "lang": "@language",
+            "value": "@value"
+        },
+        "@id": {
+            "pattern": "{0}",
+            "params": ["@id"]
+        },
+        "termName": {
+            "pattern": "{0}",
+            "params": ["/graph/uri=@id/prefLabel"]
+        },
+        "vocabularyName": {
+            "pattern": "{0}",
+            "params": ["/graph/type=skos:ConceptScheme/prefLabel"]
+        },
+        "vocabularyUri": {
+            "pattern": "{0}",
+            "params": ["/graph/type=skos:ConceptScheme/uri"]
+        }
+    }
+}
+]


### PR DESCRIPTION
This is a quick attempt to make an example using skosmos with the keyword field. It puts the term URI in the keywordValue field (since there is no keywordURI field and this is what one would do if keyword were a primitive field) while still filling in the keywordVocabulary and keywordVocabularyURI fields. 

It also updates the skos demo server address (as in #15).

I've tested the basic input/display functionality and metadata export. 