### PR TITLE
Add headers configuration

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -213,6 +213,20 @@ To handle multiple fields, this example changes:
 
 When the skosmos Javascript runs on this type of field, it hides all child fields and displays and allows input for the term uri as it normally would. However, when a slection is made, the script populates the values for all 4 fields. This simplfies using a controlled vocabulary service with an existing field (although a termURI field is needed and would have to be added to use skosmos with the citation.keyword field.) One limitation of this approach is that the child fields for the term and vocabular name only store the value for the current language (versus the full set of translations). 
 
+#Add HTTP headers to external vocabulary service request
+
+Some vocabulary services need specific HTTP headers. For example, Ontoportal need API KEY send by "Authorization" HTTP header. In this case, headers can be parameter with "headers" field, which must be added into JSON configuration file, like below :
+
+    {
+      "headers" : {
+        "Accept": "application/json",
+        "Authorization": "Basic YWxhZGRpbjpvcGVuc2VzYW1l"
+      }
+    }
+
+This headers can be recovered in Javascript with "data-cvoc-headers" attribute, and use to send them to external services.
+Make sure to send only the HTTP headers required and allowed according to the external vocabulary service CORS rules.
+
 #How to make a new Javascript for your Service/Vocabulary
 
 The skosmos.js and people.js scripts are good examples to start from. people.js is appropriate for single fields (it could be extended to handle multiple fields but has not) and for services that provide a single vocabulary choice. skosmos.js is an example that handles both multiple vocabularies and managed fields.

--- a/examples/config/CVocConf.schema.json
+++ b/examples/config/CVocConf.schema.json
@@ -197,6 +197,21 @@
                 ]
             },
 
+            "headers":
+            {
+                "$id": "#/fieldconfig/properties/headers",
+                "type": "object",
+                "title": "HTTP request headers",
+                "description": "HTTP request headers send to the service. This can be useful for specifying the response format, or if the service requires a mandatory HTTP header.",
+                "examples":
+                [
+                    {
+                        "Accept": "application/json",
+                        "Authorization": "Basic YWxhZGRpbjpvcGVuc2VzYW1l"
+                    }
+                ]
+            },
+
             "cvoc-url": 
             {
                 "$id": "#/fieldconfig/properties/cvoc-url",


### PR DESCRIPTION
Required [IQSS/dataverse/#10316](https://github.com/IQSS/dataverse/issues/10316) which adds the ability in Dataverse to configure HTTP headers for external vocabulary services.

This functionality is required for adding Ontoportal integration, which requires an api key that must be supplied either in the HTTP header, or as a request parameter.