### PR TITLE
edit config to allow setting lc field value vie API & keep sandbox config in separate file    

### DIFF
--- a/packages/local_contexts/lc-cvoc-conf.json
+++ b/packages/local_contexts/lc-cvoc-conf.json
@@ -9,7 +9,11 @@
     "cvoc-url": "https://sandbox.localcontextshub.org/",
     "managed-fields": {},
     "languages": "",
-    "vocabs": {},
+    "vocabs": {
+      "localcontexts": {
+        "uriSpace": "https://sandbox.localcontextshub.org"
+      }
+    },
     "retrieval-filtering": {
       "@context": {
         "scheme": "http://www.w3.org/2004/02/skos/core#inScheme"

--- a/packages/local_contexts/lc-cvoc-conf.json
+++ b/packages/local_contexts/lc-cvoc-conf.json
@@ -4,14 +4,14 @@
     "term-uri-field": "LCProjectUrl",
     "js-url": ["https://gdcc.github.io/dataverse-external-vocab-support/packages/local_contexts/local_contexts.js", "https://gdcc.github.io/dataverse-external-vocab-support/scripts/cvocutils.js"],
     "protocol": "localcontexts",
-    "retrieval-uri": "https://sandbox.localcontextshub.org/api/v1/projects/{0}",
+    "retrieval-uri": "https://localcontextshub.org/api/v1/projects/{0}",
     "allow-free-text": false,
-    "cvoc-url": "https://sandbox.localcontextshub.org/",
+    "cvoc-url": "https://localcontextshub.org/",
     "managed-fields": {},
     "languages": "",
     "vocabs": {
       "localcontexts": {
-        "uriSpace": "https://sandbox.localcontextshub.org"
+        "uriSpace": "https://localcontextshub.org"
       }
     },
     "retrieval-filtering": {

--- a/packages/local_contexts/lc-sandbox-cvoc-conf.json
+++ b/packages/local_contexts/lc-sandbox-cvoc-conf.json
@@ -1,0 +1,29 @@
+[
+  {
+    "field-name": "LCProjectUrl",
+    "term-uri-field": "LCProjectUrl",
+    "js-url": ["https://gdcc.github.io/dataverse-external-vocab-support/packages/local_contexts/local_contexts.js", "https://gdcc.github.io/dataverse-external-vocab-support/scripts/cvocutils.js"],
+    "protocol": "localcontexts",
+    "retrieval-uri": "https://sandbox.localcontextshub.org/api/v1/projects/{0}",
+    "allow-free-text": false,
+    "cvoc-url": "https://sandbox.localcontextshub.org/",
+    "managed-fields": {},
+    "languages": "",
+    "vocabs": {
+      "localcontexts": {
+        "uriSpace": "https://sandbox.localcontextshub.org"
+      }
+    },
+    "retrieval-filtering": {
+      "@context": {
+        "scheme": "http://www.w3.org/2004/02/skos/core#inScheme"
+      },
+      "@id": {
+        "pattern": "{0}",
+        "params": [
+          "@id"
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
I added field `localcontexts.uriSpace` to the lchub url, which is required, in order to set the field (LCProjectUrl) via the API, when `allow-free-text` is set to false.

Also created a separate config file for the sandbox configuration. 