### PR TITLE
remove '/' from project link in the built html.

### DIFF
--- a/packages/local_contexts/local_contexts.js
+++ b/packages/local_contexts/local_contexts.js
@@ -235,7 +235,7 @@ function cvoc_lc_buildLCProjectPopup(project, width = 120) {
                 </a>
             </div>
             <div style="align-items: center;display: flex;margin-right: 8px;font-size: 14px;">
-                <a id="project-link" style="font-weight: bold; color: #007585; cursor: pointer; font-size: 14px; text-decoration: underline;" href="${project.project_page}/" target="_blank" rel="noopener noreferrer">${project.title}</a>
+                <a id="project-link" style="font-weight: bold; color: #007585; cursor: pointer; font-size: 14px; text-decoration: underline;" href="${project.project_page}" target="_blank" rel="noopener noreferrer">${project.title}</a>
             </div>
         </div>
         </div>`


### PR DESCRIPTION
fix broken links to LC project page.

the href was href="${project.project_page}**/**"  .
However when the project is added, it already includes an / at the end, which then turns the link to 
https://localcontextshub.org/projects/xxxxx//
which fails.

this removal seems safe, because both
https://localcontextshub.org/projects/xxxxx
and 
https://localcontextshub.org/projects/xxxxx/

work fine.

