### PR TITLE
LC above fold and link fixes

### DIFF
--- a/packages/local_contexts/cvocLocalContexts.tsv
+++ b/packages/local_contexts/cvocLocalContexts.tsv
@@ -1,5 +1,5 @@
 #metadataBlock	name	dataverseAlias	displayName	blockURI												
 	LocalContextsCVoc		Local Contexts
 #datasetField	name	title	description	watermark	 fieldType	displayOrder	displayFormat	advancedSearchField	allowControlledVocabulary	allowmultiples	facetable	displayoncreate	required	parent	metadatablock_id	termURI
-	LCProjectUrl	Local Contexts Project	Local Contexts project url	Project url	url	1	"<a href=""#VALUE"" target=""_blank"" rel=""noopener"">#VALUE</a>"	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		LocalContextsCVoc
+	LCProjectUrl	Local Contexts Project	Local Contexts project url	Project url	url	1	<a href="#VALUE" target="_blank" rel="noopener">#VALUE</a>	FALSE	FALSE	FALSE	FALSE	TRUE	FALSE		LocalContextsCVoc
 #controlledVocabulary	DatasetField	Value	identifier	displayOrder												

--- a/packages/local_contexts/local_contexts.js
+++ b/packages/local_contexts/local_contexts.js
@@ -29,33 +29,34 @@ async function cvoc_lc_viewProject() {
       let lcContainerElement = cvoc_lc_buildLCProjectPopup(project)
       if (!$.isEmptyObject(lcContainerElement)) {
         projectField.html(lcContainerElement)
+      } else {
+        projectField.html(`<span style="margin:0px 5px 0px 5px">Project Not Found:</span><a href="${fullUrl}" target="_blank" rel="noopener">${fullUrl}</a>`)
       }
       //Dataverse-specific, temporary - see below
       aboveFoldServiceUrl = projectField.attr("data-cvoc-service-url")
     }
-    // Temporary - Dataverse doesn't currently support managing a field 'above the fold' on the dataset page
-    // To make this script work for the LCProjectUrl field in the LocalContextsCVoc metadatablock when the
-    // :CustomDatasetSummaryFields setting includes it, the following section looks for the above-fold field
-    // using a Dataverse-specific mechanism. This mechanism also assumes that only one field is using this
-    // script/that all use the same data-cvoc-service-url. The aboveFoldServiceUrl variable is set to that value
-    // (since the field found here does not include data-cvoc-* attributes at all)
-    //
-    // If/when Dataverse is enhanced to annotate this above-fold field appropriately, this section won't be needed.
-    //
-    const aboveFold = $('#LCProjectUrl')
-    if (aboveFold.length === 1) {
-      const td = aboveFold.children('td')
-      if (!td.hasClass('expanded')) {
-        var url = td.children('a').text()
-
-        td.addClass('expanded')
-        const project = await cvoc_lc_LoadOrFetch(url, aboveFoldServiceUrl)
-        //console.log(JSON.stringify(project));
-        let lcContainerElement = cvoc_lc_buildLCProjectPopup(project, 60)
-        //console.log(lcContainerElement);
-        if (!$.isEmptyObject(lcContainerElement)) {
-          td.html(lcContainerElement)
-        }
+  }
+  // Temporary - Dataverse doesn't currently support managing a field 'above the fold' on the dataset page
+  // To make this script work for the LCProjectUrl field in the LocalContextsCVoc metadatablock when the
+  // :CustomDatasetSummaryFields setting includes it, the following section looks for the above-fold field
+  // using a Dataverse-specific mechanism. This mechanism also assumes that only one field is using this
+  // script/that all use the same data-cvoc-service-url. The aboveFoldServiceUrl variable is set to that value
+  // (since the field found here does not include data-cvoc-* attributes at all)
+  //
+  // If/when Dataverse is enhanced to annotate this above-fold field appropriately, this section won't be needed.
+  //
+  const aboveFold = $('#LCProjectUrl')
+  if ((aboveFold.length === 1) && aboveFoldServiceUrl) {
+    const td = aboveFold.children('td')
+    if (!td.hasClass('expanded')) {
+      var url = td.children('a').text()
+       td.addClass('expanded')
+      const project = await cvoc_lc_LoadOrFetch(url, aboveFoldServiceUrl)
+      let lcContainerElement = cvoc_lc_buildLCProjectPopup(project, 60)
+      if (!$.isEmptyObject(lcContainerElement)) {
+        td.html(lcContainerElement)
+      } else {
+        td.html(`<span style="margin:0px 5px 0px 5px">Project Not Found:</span><a href="${url}" target="_blank" rel="noopener">${url}</a>`)
       }
     }
   }
@@ -150,7 +151,7 @@ async function cvoc_lc_editProject() {
           cache: true
         }
       })
-      
+
       //Add a tab stop and key handling to allow the clear button to be selected via tab/enter
       const observer = new MutationObserver((mutationList, observer) => {
         var button = $('#' + selectId).parent().find('.select2-selection__clear');
@@ -166,8 +167,8 @@ async function cvoc_lc_editProject() {
         childList: true,
         subtree: true }
       );
-      
-      
+
+
       // If the input has a value already, format it the same way as if it
       // were a new selection
       var id = projectInput.val();
@@ -192,7 +193,8 @@ async function cvoc_lc_editProject() {
       })
       // When a selection is cleared, clear the hidden input
       $('#' + selectId).on('select2:clear', function(e) {
-        $("input[data-lc='" + num + "']").attr('value', '');
+        //In other scripts, val() and attr() do different things - val() was required to consistently get info back to Dataverse
+        $("input[data-lc='" + num + "']").val('').attr('value', '');
       });
       //When the field is selected via keyboard, move the focus and cursor to the new input
       $('#' + selectId).on('select2:open', function(e) {
@@ -235,7 +237,7 @@ function cvoc_lc_buildLCProjectPopup(project, width = 120) {
                 </a>
             </div>
             <div style="align-items: center;display: flex;margin-right: 8px;font-size: 14px;">
-                <a id="project-link" style="font-weight: bold; color: #007585; cursor: pointer; font-size: 14px; text-decoration: underline;" href="${project.project_page}/" target="_blank" rel="noopener noreferrer">${project.title}</a>
+                <a id="project-link" style="font-weight: bold; color: #007585; cursor: pointer; font-size: 14px; text-decoration: underline;" href="${project.project_page}" target="_blank" rel="noopener noreferrer">${project.title}</a>
             </div>
         </div>
         </div>`

--- a/packages/local_contexts/local_contexts.js
+++ b/packages/local_contexts/local_contexts.js
@@ -151,7 +151,7 @@ async function cvoc_lc_editProject() {
           cache: true
         }
       })
-
+      
       //Add a tab stop and key handling to allow the clear button to be selected via tab/enter
       const observer = new MutationObserver((mutationList, observer) => {
         var button = $('#' + selectId).parent().find('.select2-selection__clear');
@@ -167,8 +167,8 @@ async function cvoc_lc_editProject() {
         childList: true,
         subtree: true }
       );
-
-
+      
+      
       // If the input has a value already, format it the same way as if it
       // were a new selection
       var id = projectInput.val();


### PR DESCRIPTION
This PR fixes several issues:

The above-fold display could sometimes remain as a simple link due to the script running twice (on an ajax page refresh). The change here assures that the above-fold field is only updated once/only when the service url has been found from an unexpanded entry in the metadata table.

It adds a 'Project Not Found:" prefix if/when the call to LocalContexts fails (seen on the sandbox when a test project has been deleted).

It fixes the non-LC script formatting of the field that Dataverse creates. The original TSV used the convention of adding " marks around a string and using "" to indicate real quote marks in the string. This resulted in Dataverse producing HTML like 
`"<a href="" https:="" sandbox.localcontextshub.org="" projects="" 306f39fe-9610-47a9-b264-5f17895e1657="" ""="" target="" _blank""="" rel="" noopener""="">https://sandbox.localcontextshub.org/projects/306f39fe-9610-47a9-b264-5f17895e1657/</a>"` The PR removes the start/end quotes and using single " chars internal to the string. That shows the URL without start/end quote marks and generates a usable link to the project. (Now that script rewrites the link in the Project Not Found case, Dataverse's internal formatting would only appear if the script is ever removed/deregistered. So reinstalling the metadatablock is not really required for proper operation with the script.)

It also adds a .val('') when resetting the hidden input. In other scripts (ORCID/ROR) I've seen issues with using the attr('value', ) method on a hidden input - that appears to set the value of the input in the DOM tree one can see in the browser console, but doesn't necessarily/always cause the value to be picked up to be sent back to Dataverse when the metadata is saved. Using the jQuery  .val() method does (perhaps it triggers a change event that attr doesn't?). In any case, .val is needed in those other scripts and I've called both .val() and .attr() so the change can be seen in the DOM tree as well. The change here adds the .val() method to be consistent - if it has an effect, it would be to fix a possible intermittent issue with cancelling a project selection not removing the LC project metadata when the metadata is saved - I may have seen this but am not sure - might only have been the other scripts.