### PR TITLE
ROR Search update and minor ORCID fix

### DIFF
--- a/scripts/people.js
+++ b/scripts/people.js
@@ -53,7 +53,7 @@ function expandPeople() {
                         $(personElement).show();
                         let index = $(personElement).attr('data-cvoc-index');
                         if (index !== undefined) {
-                            $(personElement).siblings("[data-cvoc-index='" + index + "']").show().removeClass('hidden');
+                            $(personElement).siblings("[data-cvoc-index='" + index + "']").show().removeClass('hidden').removeAttr('hidden');
                         }
                         //Generic logging if not 404
                         if (jqXHR.status != 404) {
@@ -66,7 +66,7 @@ function expandPeople() {
                 $(personElement).show();
                 let index = $(personElement).attr('data-cvoc-index');
                 if (index !== undefined) {
-                    $(personElement).siblings("[data-cvoc-index='" + index + "']").show().removeClass('hidden');
+                    $(personElement).siblings("[data-cvoc-index='" + index + "']").show().removeClass('hidden').removeAttr('hidden');
                 }
             }
         }

--- a/scripts/ror.js
+++ b/scripts/ror.js
@@ -169,8 +169,9 @@ function updateRorInputs() {
                         term = params.term;
                         if (!term) {
                             term = "";
+                        } else {
+                            term = term.replace(/([+\-&|!(){}[\]^"~*?:\\\/])/g, "\\$1") + "*";
                         }
-                        term = term.replace(/([+\-&|!(){}[\]^"~*?:\\\/])/g, "\\$1");
                         var query = {
                             query: term,
                         }


### PR DESCRIPTION
ROR by default doesn't search for partial words, which we probably want for a typing completion as we do. This PR adds a * to the end of the submitted query to do that.
I've also added a minor fix to the ORCID script from QDR - an error where a field was staying hidden when it shouldn't. I no longer have details about the specific scenario.