### PR TITLE
update demo skosmos url per #15

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -82,10 +82,10 @@ Here's the equivalent configuration for a skosmos service where the field has be
     {
       "field-name": "skosterm",
       "term-uri-field": "skosterm",
-      "cvoc-url": "https://skosmos.dev.finto.fi/",
+      "cvoc-url": "https://demo.skosmos.org/",
       "js-url": "https://gdcc.github.io/dataverse-external-vocab-support/scripts/skosmos.js",
       "protocol": "skosmos",
-      "retrieval-uri": "https://skosmos.dev.finto.fi/rest/v1/data?uri={0}",
+      "retrieval-uri": "https://demo.skosmos.org/rest/v1/data?uri={0}",
       "allow-free-text": false,
       "languages": "en, uk, es, zh, ar, tr, lo, sk, th, pt, hu, pl, de, cs, it, fr, hi, ja, ro, fa",
       "vocabs": {
@@ -152,10 +152,10 @@ The final example, below, shows a skosmos service being associated with a compou
     {
       "field-name": "cvocDemo",
       "term-uri-field": "cvocDemoTermURI",
-      "cvoc-url": "https://skosmos.dev.finto.fi/",
+      "cvoc-url": "https://demo.skosmos.org/",
       "js-url": "https://gdcc.github.io/dataverse-external-vocab-support/scripts/skosmos.js",
       "protocol": "skosmos",
-      "retrieval-uri": "https://skosmos.dev.finto.fi/rest/v1/data?uri={0}",
+      "retrieval-uri": "https://demo.skosmos.org/rest/v1/data?uri={0}",
       "term-parent-uri": "",
       "allow-free-text": false,
       "vocabs": {

--- a/examples/config/CVocConf.schema.json
+++ b/examples/config/CVocConf.schema.json
@@ -15,10 +15,10 @@
             {
                 "field-name": "cvocDemo",
                 "term-uri-field": "cvocDemoTermURI",
-                "cvoc-url": "https://skosmos.dev.finto.fi/",
+                "cvoc-url": "https://demo.skosmos.org/",
                 "js-url": "https://gdcc.github.io/dataverse-external-vocab-support/scripts/skosmos.js",
                 "protocol": "skosmos",
-                "retrieval-uri": "https://skosmos.dev.finto.fi/rest/v1/data?uri={0}",
+                "retrieval-uri": "https://demo.skosmos.org/rest/v1/data?uri={0}",
                 "term-parent-uri": "",
                 "allow-free-text": false,
                 "languages": "en, fr, es, ru",
@@ -220,7 +220,7 @@
                 "description": "For service protocols such as skosmos where there are multiple services available, this parameter specifies the URL of the specific service to connect to",
                 "examples": 
                 [
-                    "https://skosmos.dev.finto.fi/"
+                    "https://demo.skosmos.org/"
                 ]
             },
 
@@ -282,7 +282,7 @@
                 "default": "",
                 "examples": 
                 [
-                    "https://skosmos.dev.finto.fi/rest/v1/data?uri={0}",
+                    "https://demo.skosmos.org/rest/v1/data?uri={0}",
                     "https://pub.orcid.org/v3.0/{0}/person",
                     "https://data.agroportal.lirmm.fr/ontologies/{keywordVocabulary}/classes/{encodeUrl:keywordTermURI}"
                 ]

--- a/examples/config/demos/cvoc-conf.json
+++ b/examples/config/demos/cvoc-conf.json
@@ -1,10 +1,10 @@
 [{
         "field-name": "compoundDemo",
         "term-uri-field": "compoundDemoTermURI",
-        "cvoc-url": "https://skosmos.dev.finto.fi/",
+        "cvoc-url": "https://demo.skosmos.org/",
         "js-url": "https://gdcc.github.io/dataverse-external-vocab-support/scripts/skosmos.js",
         "protocol": "skosmos",
-        "retrieval-uri": "https://skosmos.dev.finto.fi/rest/v1/data?uri={0}",
+        "retrieval-uri": "https://demo.skosmos.org/rest/v1/data?uri={0}",
         "term-parent-uri": "",
         "allow-free-text": false,
         "languages":"en, fr, es, ru",
@@ -84,10 +84,10 @@
     {
         "field-name": "skosterm",
         "term-uri-field": "skosterm",
-        "cvoc-url": "https://skosmos.dev.finto.fi/",
+        "cvoc-url": "https://demo.skosmos.org/",
         "js-url": "https://gdcc.github.io/dataverse-external-vocab-support/scripts/skosmos.js",
         "protocol": "skosmos",
-        "retrieval-uri": "https://skosmos.dev.finto.fi/rest/v1/data?uri={0}",
+        "retrieval-uri": "https://demo.skosmos.org/rest/v1/data?uri={0}",
         "allow-free-text": true,
         "languages":"en, uk, es, zh, ar, tr, lo, sk, th, pt, hu, pl, de, cs, it, fr, hi, ja, ro, fa",
         "vocabs":{

--- a/examples/config/demos/cvoc-conf.singlevocab.json
+++ b/examples/config/demos/cvoc-conf.singlevocab.json
@@ -1,10 +1,10 @@
 [{
         "field-name": "compoundDemo",
         "term-uri-field": "compoundDemoTermURI",
-        "cvoc-url": "https://skosmos.dev.finto.fi/",
+        "cvoc-url": "https://demo.skosmos.org/",
         "js-url": "https://gdcc.github.io/dataverse-external-vocab-support/scripts/skosmos.js",
         "protocol": "skosmos",
-        "retrieval-uri": "https://skosmos.dev.finto.fi/rest/v1/data?uri={0}",
+        "retrieval-uri": "https://demo.skosmos.org/rest/v1/data?uri={0}",
         "term-parent-uri": "",
         "allow-free-text": false,
         "languages":"en, fr, es, ru",
@@ -84,10 +84,10 @@
     {
         "field-name": "skosterm",
         "term-uri-field": "skosterm",
-        "cvoc-url": "https://skosmos.dev.finto.fi/",
+        "cvoc-url": "https://demo.skosmos.org/",
         "js-url": "https://gdcc.github.io/dataverse-external-vocab-support/scripts/skosmos.js",
         "protocol": "skosmos",
-        "retrieval-uri": "https://skosmos.dev.finto.fi/rest/v1/data?uri={0}",
+        "retrieval-uri": "https://demo.skosmos.org/rest/v1/data?uri={0}",
         "allow-free-text": false,
         "languages":"en, uk, fr, ru",
         "vocabs":{


### PR DESCRIPTION
This updates the skosmos demo server url in all docs/examples. (new url known to work as of 8/20/25)

Closes #15 