### PR TITLE
GDCC-42/Fix allowfreetext handling

### DIFF
--- a/scripts/fundreg.js
+++ b/scripts/fundreg.js
@@ -102,7 +102,7 @@ function updateFunderInputs() {
                 '<select id=' + selectId + ' class="form-control add-resource select2" tabindex="-1" aria-hidden="true">');
             $("#" + selectId).select2({
                 theme: "classic",
-                tags: $(funderInput).attr('data-cvoc-allowfreetext'),
+                tags: $(funderInput).data("cvoc-allowfreetext"),
                 delay: 500,
                 templateResult: function(item) {
                     // No need to template the searching text

--- a/scripts/people.js
+++ b/scripts/people.js
@@ -113,7 +113,7 @@ function updatePeopleInputs() {
             var orcidSearchUrl = orcidBaseUrl.replace("https://","https://pub.") + "v3.0/expanded-search";
             $("#" + selectId).select2({
                 theme: "classic",
-                tags: $(personInput).attr('data-cvoc-allowfreetext'),
+                tags: $(personInput).data("cvoc-allowfreetext"),
                 delay: 500,
                 templateResult: function(item) {
                     // No need to template the searching text

--- a/scripts/ror.js
+++ b/scripts/ror.js
@@ -123,7 +123,7 @@ function updateRorInputs() {
                 '<select id=' + selectId + ' class="form-control add-resource select2" tabindex="0" >');
             $("#" + selectId).select2({
                 theme: "classic",
-                tags: $(rorInput).attr('data-cvoc-allowfreetext'),
+                tags: $(rorInput).data("cvoc-allowfreetext"),
                 delay: 500,
                 templateResult: function(item) {
                     // No need to template the searching text

--- a/scripts/skosmos.js
+++ b/scripts/skosmos.js
@@ -112,7 +112,7 @@ function updateSkosmosInputs() {
             let managedFields = JSON.parse($(skosmosInput).attr('data-cvoc-managedfields'));
             let parentField = $(skosmosInput).attr('data-cvoc-parent');
             let termParentUri = $(skosmosInput).attr('data-cvoc-filter');
-            let allowFreeText = $(skosmosInput).attr('data-cvoc-allowfreetext');
+            let allowFreeText = $(skosmosInput).data("cvoc-allowfreetext");
             let placeholder = skosmosInput.hasAttribute("data-cvoc-placeholder") ? $(skosmosInput).attr('data-cvoc-placeholder') : "Select a term";
             let selectId = "skosmosAddSelect_" + num;
             //Pick the first entry as the default to start with when there is more than one vocab


### PR DESCRIPTION
This PR adopts the syntax from the ontoportal script to leverage jquery's parsing of string values into booleans via 
.data("cvoc-allowfreetext");

An alternate approach would be to do:
$(funderInput).attr('data-cvoc-allowfreetext')?.toLowerCase() === "true" || 
          $(funderInput).attr('data-cvoc-allowfreetext') === true,

It sounds like .data() caches values and may have problems if the attribute is being reset, but since that is not our case, it looks like the shorter syntax should be fine.

Closes: #42 