### PR TITLE
Use Organization's Canonical Name

### DIFF
--- a/scripts/ror.js
+++ b/scripts/ror.js
@@ -62,9 +62,9 @@ function expandRors() {
                             },
                             success: function(ror, status) {
                                 // If found, construct the HTML for display
-                                // Find the display name (type: "ror_display" or "label")
+                                // Find the display name (type: "ror_display")
                                 const displayName = ror.names.find(n => 
-                                    n.types && (n.types.includes("ror_display") || n.types.includes("label"))
+                                    n.types && n.types.includes("ror_display")
                                 )?.value || ror.id;
                                 
                                 // Find all acronyms
@@ -199,9 +199,9 @@ function updateRorInputs() {
                                 .sort((a, b) => Number(b.status === 'active') - Number(a.status === 'active'))
                                 // Extract display name and acronyms from the names array
                                 .map(org => {
-                                    // Find the display name (type: "ror_display" or "label")
+                                    // Find the display name (type: "ror_display")
                                     const displayName = org.names.find(n => 
-                                        n.types && (n.types.includes("ror_display") || n.types.includes("label"))
+                                        n.types && n.types.includes("ror_display")
                                     )?.value || org.id;
                                     
                                     // Find all acronyms


### PR DESCRIPTION
ROR defines one name as the ror_display name - what they use as an organization's canonical name for the org's ROR page. Our script has been looking for that OR the first "label". Labels can be in other language, leading to the issue, for example, of a US university (University of Washington in St. Louis) being shown in Spanish in an English language Dataverse display.

As a first step towards a fix, this PR just looks only for the ror_display entry, which should always exist.  As noted in #52, a more thorough fix could look for the label in the language used in the Dataverse display.